### PR TITLE
Don't try to get executable path on FreeBSD

### DIFF
--- a/src/lib/utility/os.cpp
+++ b/src/lib/utility/os.cpp
@@ -104,6 +104,8 @@ namespace os
 		return exe.parent_path();
 #elif __amigaos4__
 		return "";
+#elif defined(__FreeBS__)
+		return "";
 #else
 		// determine full path to application
 		// this needs /proc support that should be available


### PR DESCRIPTION
`/proc` is optional on FreeBSD and executable path is not useful for any purpose